### PR TITLE
Import tailwindcss module in postcss.config.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	plugins: [
 	  require('precss'),
-    tailwindcss('./tailwind.js'),
+    require('tailwindcss')('./tailwind.js'),
     require('autoprefixer'),
 	]
 


### PR DESCRIPTION
I haven't actually pulled down the project to test but at first glance the first issue I noticed was that you were trying to call the `tailwindcss` function without actually importing the module. This should hopefully fix your problem, or at the very least get you a little bit closer.