### PR TITLE
[#6]: Validate HTML before inlining critical CSS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](semver).
 - Beautify HTML.
 - Minify HTML in production.
 - Inline critical CSS. [#5]
+- Validate HTML. [#6]
 - Bundle JavaScript modules. [#11]
 - Transpile modern JavaScript to ES5. [#12]
 - Polyfill modern JavaScript to ES5. [#13]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ const critical = require('critical')
 const beautify = require('gulp-beautify')
 const beautifyConfig = config.get('vendor.beautify')
 const htmlmin = require('gulp-htmlmin')
+const validator = require('gulp-html')
 
 // CSS
 const gulpStylelint = require('gulp-stylelint')
@@ -168,7 +169,7 @@ async function html (callback) {
 		await isWatching ? ssg.watch() : ssg.write()
 	})
 
-	callback()
+	return callback()
 }
 exports.html = html
 
@@ -332,9 +333,10 @@ exports.javascript = javascript
  */
 function validate () {
 	const merged = merge(
-		// @todo [#6]: Validate HTML.
-		// - https://github.com/validator/gulp-html
-		// - https://github.com/center-key/gulp-w3c-html-validator
+		// Validate HTML.
+		src(paths.html.temp)
+			.pipe(validator())
+			.pipe(dest(paths.dest)),
 
 		// Validate CSS.
 		src(paths.css.written)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "gulp-cli": "^2.3.0",
     "gulp-connect": "^5.7.0",
     "gulp-eslint": "^6.0.0",
+    "gulp-html": "^3.2.0",
     "gulp-htmllint": "0.0.19",
     "gulp-htmlmin": "^5.0.1",
     "gulp-if": "^3.0.0",


### PR DESCRIPTION
## Summary
Validate HTML written to `/build/temp` before inlining critical CSS. Exit on error.

## Testing
- Run `npm start`
- See the build pass without validation errors

## Issue(s)
Closes #6

## Changelog

### Added
- Validate HTML before inlining critical CSS. [#6]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
