### PR TITLE
#5: Inline critical CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](semver).
 - Lint HTML. [#2]
 - Lint Sass. [#7]
 - Lint JavaScript.
+- Inline critical CSS. [#5]
 - Process Sass. [#20]
 - Add JavaScript testing. [#15]
 - Add a few gulpfile and eleventy config unit tests. [#15]

--- a/config/default.js
+++ b/config/default.js
@@ -14,16 +14,17 @@ module.exports = {
 	},
 	html: {
 		beautify: require('./html/beautify'),
-		htmlmin: require('./html/htmlmin'),
-		htmllint: require('./html/htmllint')
+		critical: require('./html/critical'),
+		htmllint: require('./html/htmllint'),
+		htmlmin: require('./html/htmlmin')
 	},
 	sass: {
 		'node-sass': require('./sass/node-sass'),
 		rename: require('./sass/rename')
 	},
 	javascript: {
-		eslint: require('./javascript/eslint'),
 		ava: require('./javascript/ava'),
+		eslint: require('./javascript/eslint'),
 		rename: require('./javascript/rename')
 	},
 	site: {

--- a/config/html/critical.js
+++ b/config/html/critical.js
@@ -1,0 +1,10 @@
+/**
+ * critical configuration.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
+module.exports = {
+  inline: true
+}

--- a/config/sass/rename.js
+++ b/config/sass/rename.js
@@ -5,8 +5,13 @@
  *
  * @type {Object}
  */
-module.exports = path => {
-  path.dirname = path.dirname
-  	.replace('/assets', '')
-  	.replace('/sass', '/css')
+module.exports = {
+	dest: path => {
+	  path.dirname = path.dirname
+	  	.replace('/assets', '')
+	  	.replace('/sass', '/css')
+	},
+	min: path => {
+		path.basename += '.min'
+	}
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",
     "ava": "^3.14.0",
+    "critical": "^2.0.6",
     "del": "^6.0.0",
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.0",

--- a/src/pshry.com/assets/sass/bundle.scss
+++ b/src/pshry.com/assets/sass/bundle.scss
@@ -1,0 +1,3 @@
+body {
+	font-size: 1em;
+}

--- a/src/pshry.com/data/colophon.js
+++ b/src/pshry.com/data/colophon.js
@@ -1,5 +1,12 @@
 const site = require('./site')
 
+/**
+ * Colophon data object.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
 module.exports = {
   copyright: `&copy; ${site.year} ${site.title}. All rights reserved.`,
 }

--- a/src/pshry.com/data/env.js
+++ b/src/pshry.com/data/env.js
@@ -1,0 +1,12 @@
+const config = require('config')
+
+/**
+ * Environment data object.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
+module.exports = {
+  isProduction: config.get('isProduction')
+}

--- a/src/pshry.com/data/masthead.js
+++ b/src/pshry.com/data/masthead.js
@@ -1,5 +1,12 @@
 const site = require('./site')
 
+/**
+ * Masthead data object.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
 module.exports = {
   title: site.title,
 }

--- a/src/pshry.com/data/site.js
+++ b/src/pshry.com/data/site.js
@@ -1,5 +1,12 @@
 const config = require('config')
 
+/**
+ * Site data object.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
 module.exports = {
   lang: 'en-US',
   title: 'Paul Shryock',

--- a/src/pshry.com/includes/components/colophon.liquid
+++ b/src/pshry.com/includes/components/colophon.liquid
@@ -1,0 +1,3 @@
+    <footer class="colophon">
+      <p class="colophon__copyright">{{ colophon.copyright }}</p>
+    </footer>

--- a/src/pshry.com/includes/components/masthead.liquid
+++ b/src/pshry.com/includes/components/masthead.liquid
@@ -1,0 +1,7 @@
+    <header class="masthead">
+      {%- if slug == '.' %}
+      <h1 class="masthead__title">{{ masthead.title }}</h1>
+      {%- else %}
+      <p class="masthead__title">{{ masthead.title }}</p>
+      {%- endif %}
+    </header>

--- a/src/pshry.com/includes/meta/head.liquid
+++ b/src/pshry.com/includes/meta/head.liquid
@@ -1,0 +1,8 @@
+  <head>
+    <title>{{ site.title }}</title>
+    {%- if env.isProduction %}
+    <link rel="stylesheet" href="/css/bundle.min.css">
+    {%- else %}
+    <link rel="stylesheet" href="/css/bundle.css">
+    {%- endif %}
+  </head>

--- a/src/pshry.com/layouts/scaffold.liquid
+++ b/src/pshry.com/layouts/scaffold.liquid
@@ -1,21 +1,11 @@
 <!DOCTYPE html>
 <html class="no-js" lang="{{ site.lang }}">
-  <head>
-    <title>{{ site.title }}</title>
-  </head>
+{% include meta/head %}
   <body class="site">
-    <header class="masthead">
-      {%- if slug == '.' %}
-      <h1 class="masthead__title">{{ masthead.title }}</h1>
-      {%- else %}
-      <p class="masthead__title">{{ masthead.title }}</p>
-      {%- endif %}
-    </header>
+    {% include components/masthead %}
     <main>
       {{ content }}
     </main>
-    <footer class="colophon">
-      <p class="colophon__copyright">{{ colophon.copyright }}</p>
-    </footer>
+    {% include components/colophon %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
### Why is critical-path CSS important?

> CSS is required to construct the render tree for your pages and JavaScript will often block on CSS during initial construction of the page. You should ensure that any non-essential CSS is marked as non-critical (e.g. print and other media queries), and that the amount of critical CSS and the time to deliver it is as small as possible.

### Why should critical-path CSS be inlined?

> For best performance, you may want to consider inlining the critical CSS directly into the HTML document. This eliminates additional roundtrips in the critical path and if done correctly can be used to deliver a “one roundtrip” critical path length where only the HTML is a blocking resource.

## Testing
- Run `npm start` and check rendered HTML files in `/build` for inlined critical CSS.

## Issue(s)

Closes #5

## Changelog

### Added
- Inline critical CSS. [#5]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
