### PR TITLE
#26: Minify CSS in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](semver).
 - Process Sass. [#20]
 - Post-process CSS. [#23]
 - Beautify CSS.
+- Minify CSS in production. [#26]
 - Preserve CSS sourcemaps.
 - Build HTML.
 - Beautify HTML.

--- a/config/default.js
+++ b/config/default.js
@@ -19,6 +19,7 @@ module.exports = {
 		ava: require('./vendor/ava'),
 		beautify: require('./vendor/beautify'),
 		critical: require('./vendor/critical'),
+		cssnano: require('./vendor/cssnano'),
 		eslint: require('./vendor/eslint'),
 		htmllint: require('./vendor/htmllint'),
 		htmlmin: require('./vendor/htmlmin'),

--- a/config/vendor/cssnano.js
+++ b/config/vendor/cssnano.js
@@ -1,0 +1,10 @@
+/**
+ * cssnano configuration.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
+module.exports = {
+  preset: 'default',
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,7 +225,13 @@ function css (cb) {
 		.pipe(beautify.css(config.get('vendor.beautify')))
 		// @todo [#8]: Validate CSS.
 		// - https://github.com/gchudnov/gulp-w3c-css
-		// @todo: Minify CSS.
+		// Minify CSS in production.
+		.pipe(gulpif(
+			config.get('isProduction'),
+			postcss([
+				require('cssnano')(config.get('vendor.cssnano'))
+			])
+		))
 		.pipe(gulpif(
 			config.get('isProduction'),
 			rename(config.get('vendor.rename.min'))

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "autoprefixer": "^10.1.0",
     "ava": "^3.14.0",
     "critical": "^2.0.6",
+    "cssnano": "^4.1.10",
     "del": "^6.0.0",
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.0",


### PR DESCRIPTION
## Summary

In production, serve minified CSS with sourcemaps.

## Testing
- Set `BUILD_ENV=production` in `.env`
- Run `npm start`
- Confirm that CSS ouput is minified and renamed `*.min.css`
- Confirm that HTML properly links to minified CSS file(s)
- Confirm sourcemaps are working in the browser

## Issue(s)

Closes #26

## Changelog

### Added
- Minify CSS in production. [#26]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
