### PR TITLE
[#33]: Move sourcemaps to separate files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -261,7 +261,7 @@ function css () {
 		// Rewrite directory path.
 		.pipe(rename(config.get('vendor.rename.dest')))
 		// Write sourcemaps.
-		.pipe(sourcemaps.write())
+		.pipe(sourcemaps.write('.'))
 		.pipe(dest(paths.css.dest))
 }
 exports.css = css
@@ -282,7 +282,7 @@ function javascript () {
 		// @todo [#12]: Transpile modern JavaScript.
 		// @todo [#13]: Polyfill modern JavaScript.
 		// Write sourcemaps.
-		.pipe(sourcemaps.write())
+		.pipe(sourcemaps.write('.'))
 		.pipe(dest(paths.javascript.dest))
 }
 exports.javascript = javascript


### PR DESCRIPTION
## Summary
Move sourcemaps to separate files, in order to reduce file sizes.

## Testing
- Run `npm start`
- See that output sourcemaps sit in the same directory as their file

## Issue(s)

Closes #33

## Changelog

### Changed
- Move sourcemaps to separate files.

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [ ] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
