### PR TITLE
[#31]: Move Gulp paths to config

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -21,6 +21,7 @@ module.exports = {
 		critical: require('./vendor/critical'),
 		cssnano: require('./vendor/cssnano'),
 		eslint: require('./vendor/eslint'),
+		gulp: require('./vendor/gulp'),
 		htmllint: require('./vendor/htmllint'),
 		htmlmin: require('./vendor/htmlmin'),
 		node_sass: require('./vendor/node-sass'),

--- a/config/vendor/gulp.js
+++ b/config/vendor/gulp.js
@@ -1,0 +1,70 @@
+/**
+ * gulp configuration.
+ *
+ * @since unreleased
+ *
+ * @type {Object}
+ */
+module.exports = {
+	paths: {
+		changelog: './CHANGELOG.md',
+		html: {
+			src: './src/**/*.html',
+			dest: './build',
+			get lint () {
+				return [
+					this.src,
+					this.written
+				]
+			},
+			written: './build/**/*.html'
+		},
+		svg: {
+			src: './src/**/*.svg',
+		},
+		sass: {
+			src: './src/**/sass/*.s+(a|c)ss',
+			lint: {
+				src: [
+					'./src/**/*.s+(a|c)ss',
+					'!./src/**/vendor/**/*.s+(a|c)ss'
+				],
+				dest: './src'
+			}
+		},
+		css: {
+			dest: './build'
+		},
+		javascript: {
+			config: './config/*.js',
+			src: './src/**/*.js',
+			dest: './build',
+			root: {
+				files: './*.js',
+				dotfiles: './.*.js',
+				get all () {
+					return [
+						this.files,
+						this.dotfiles
+					]
+				}
+			},
+			get lint () {
+				return {
+					src: [
+						this.config,
+						this.src,
+						this.root.files
+					],
+					dest: './'
+				}
+			},
+			test: [
+				'./*.test.js',
+				'./.*.test.js',
+				'./config/**/*.test.js',
+				'./src/**/*.test.js',
+			]
+		}
+	},
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,67 +41,7 @@ const ava = require('gulp-ava')
  *
  * @type {Object}
  */
-const paths = {
-	changelog: './CHANGELOG.md',
-	html: {
-		src: './src/**/*.html',
-		dest: './build',
-		get lint () {
-			return [
-				this.src,
-				this.written
-			]
-		},
-		written: './build/**/*.html'
-	},
-	svg: {
-		src: './src/**/*.svg',
-	},
-	sass: {
-		src: './src/**/sass/*.s+(a|c)ss',
-		lint: {
-			src: [
-				'./src/**/*.s+(a|c)ss',
-				'!./src/**/vendor/**/*.s+(a|c)ss'
-			],
-			dest: './src'
-		}
-	},
-	css: {
-		dest: './build'
-	},
-	javascript: {
-		config: './config/*.js',
-		src: './src/**/*.js',
-		dest: './build',
-		root: {
-			files: './*.js',
-			dotfiles: './.*.js',
-			get all () {
-				return [
-					this.files,
-					this.dotfiles
-				]
-			}
-		},
-		get lint () {
-			return {
-				src: [
-					this.config,
-					this.src,
-					this.root.files
-				],
-				dest: './'
-			}
-		},
-		test: [
-			'./*.test.js',
-			'./.*.test.js',
-			'./config/**/*.test.js',
-			'./src/**/*.test.js',
-		]
-	}
-}
+const paths = config.get('vendor.gulp.paths')
 exports.paths = paths
 
 /**


### PR DESCRIPTION
## Summary
Move bulky paths object out of `gulpfile.js` into its own config file.

## Testing
- Run `npm start` and verify nothing broke

## Issue(s)

Closes #31

## Changelog

### Changed
- Move Gulp paths to config. [#31]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [ ] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
