### PR TITLE
[#48]: Add fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules/
 jspm_packages/
 npm-debug.log
 package-lock.json
+vendor/
 
 # Optional npm cache directory
 .npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](semver).
 - Add favicons. [#42]
 - Optimize SVG. [#9]
 - Minify SVG in production. [#10]
+- Add fonts. [#48]
 - Bundle JavaScript modules. [#11]
 - Transpile modern JavaScript to ES5. [#12]
 - Polyfill modern JavaScript to ES5. [#13]

--- a/config/vendor/stylelint.js
+++ b/config/vendor/stylelint.js
@@ -13,6 +13,12 @@ module.exports = {
 		],
 		rules: {
 			indentation: [ 'tab', { baseIndentLevel: 1 } ],
+			'media-feature-name-no-unknown': [
+				true,
+				{
+					ignoreMediaFeatureNames: [/^prefers-reduced-/]
+				}
+			]
 		},
 	},
 	fix: true,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-unicorn": "^23.0.0",
     "fancy-log": "^1.3.3",
     "fast-glob": "^3.2.4",
+    "get-google-fonts": "^1.2.2",
     "gulp": "^4.0.2",
     "gulp-ava": "^3.0.0",
     "gulp-babel": "^8.0.0",

--- a/src/pshry.com/assets/sass/elements/_html.scss
+++ b/src/pshry.com/assets/sass/elements/_html.scss
@@ -1,0 +1,3 @@
+html {
+	font-family: $font-sans-serif;
+}

--- a/src/pshry.com/assets/sass/main.scss
+++ b/src/pshry.com/assets/sass/main.scss
@@ -1,6 +1,8 @@
 /**
  * Settings – used with preprocessors and contain font, colors definitions, etc.
  */
+@import 'settings/font-face';
+@import 'settings/fonts';
 
 /**
  * Tools – globally used mixins and functions. It’s important not to output any
@@ -21,6 +23,7 @@
  * Elements – styling for bare HTML elements (like H1, A, etc.). These come with
  * default styling from the browser so we can redefine them here.
  */
+@import 'elements/html';
 
 /**
  * Objects – class-based selectors which define undecorated design patterns, for

--- a/src/pshry.com/assets/sass/settings/_font-face.scss
+++ b/src/pshry.com/assets/sass/settings/_font-face.scss
@@ -1,0 +1,3 @@
+@media (prefers-reduced-data: no-preference) {
+	@import '../../fonts/vendor/fonts';
+}

--- a/src/pshry.com/assets/sass/settings/_fonts.scss
+++ b/src/pshry.com/assets/sass/settings/_fonts.scss
@@ -1,0 +1,15 @@
+$font-sans-serif-primary: 'Inter',
+	system-ui,
+	-apple-system,
+	'Segoe UI',
+	'Roboto',
+	'Ubuntu',
+	'Cantarell',
+	'Noto Sans',
+	sans-serif,
+	'Apple Color Emoji',
+	'Segoe UI Emoji',
+	'Segoe UI Symbol',
+	'Noto Color Emoji';
+
+$font-sans-serif: $font-sans-serif-primary;

--- a/src/pshry.com/content/headers.liquid
+++ b/src/pshry.com/content/headers.liquid
@@ -1,6 +1,8 @@
 ---
 permalink: ./_headers
 layout: ''
+scripts: false
+stylesheets: false
 ---
 /*
 	Content-Security-Policy: {{ site.csp }}

--- a/src/pshry.com/content/robots.liquid
+++ b/src/pshry.com/content/robots.liquid
@@ -1,6 +1,8 @@
 ---
 permalink: ./robots.txt
 layout: ''
+scripts: false
+stylesheets: false
 ---
 User-agent: *
 {%- if env.isProduction and env.isPublished %}

--- a/src/pshry.com/data/site.js
+++ b/src/pshry.com/data/site.js
@@ -14,6 +14,7 @@ module.exports = {
 		'script-src': "'self'",
 		'style-src': "'self'",
 		'img-src': "'self'",
+		'font-src': "'self'",
 		'manifest-src': "'self'",
 		'base-uri': "'self'",
 		'form-action': "'self'",


### PR DESCRIPTION
## Summary
Download fonts at build time and add relevant CSS. Webfonts are only requested when `prefers-reduced-data` is set to `no-preference`.

## Testing
- Run `npm run build`
- Confirm that font files are downloaded and copied to `/build/pshry.com/fonts/`
- Confirm that relevant font CSS is added to `/css/main.css`

## Issue(s)

- Closes #48
- Relates to #77

## Changelog
### Added
- Add fonts. [#48]
## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
