### PR TITLE
 [#72]: Serve unbundled JS in development 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,12 @@ and this project adheres to [Semantic Versioning](semver).
 - Minify SVG in production. [#10]
 - Add webfonts with fallbacks on slower connections or reduced data. [#48]
 - Bundle JavaScript modules. [#11]
-- Transpile modern JavaScript to ES5. [#12]
+- Transpile modern JavaScript for browsers supporting ES modules. [#12]
 - Polyfill modern JavaScript to ES5. [#13]
 - Preserve JavaScript sourcemaps.
 - Add JavaScript testing. [#15]
 - Add local development server. [#46]/[#47]
+- Serve unbundled JS in development. [#72]
 - Bump docblock and Changelog versions during new version.
 - Setup CI/CD. [#38]
 - Add Content Security Policy headers. [#65]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -669,8 +669,13 @@ async function javascript () {
 					),
 				// Write sourcemaps.
 				sourcemap: true,
-				// Transpile modern JavaScript to ES2015.
-				target: 'es2015'
+				// Transpile modern JavaScript for browsers supporting ES modules.
+				target: [
+			    'chrome61',
+			    'firefox60',
+			    'safari11',
+			    'edge16',
+			  ],
 			})
 		})
 	} catch (error) {

--- a/src/pshry.com/assets/js/main.js
+++ b/src/pshry.com/assets/js/main.js
@@ -1,5 +1,5 @@
-import { handleLoad } from './utilities/onload'
-import { Table } from './components/table'
+import { handleLoad } from './utilities/onload.js'
+import { Table } from './components/table.js'
 
 function init () {
 	handleLoad()

--- a/src/pshry.com/assets/js/utilities/onload.js
+++ b/src/pshry.com/assets/js/utilities/onload.js
@@ -1,4 +1,4 @@
-import { env, isProduction } from './env'
+import { env, isProduction } from './env.js'
 
 /**
  * Swap HTML element class .no-js for .js.

--- a/src/pshry.com/assets/sass/components/_site.scss
+++ b/src/pshry.com/assets/sass/components/_site.scss
@@ -5,7 +5,7 @@
 		color: $headline-color;
 		content: attr(data-title);
 		font-size: 10em;
-		font-weight: 1;
+		font-weight: 100;
 		line-height: 1;
 		opacity: 0.05;
 		position: absolute;


### PR DESCRIPTION
## Summary
Client-side JavaScript files are no longer bundled in local development.

## Testing
- Run `npm start` and open a browser to `localhost:8000`
- Make changes to client-side JavaScript files and refresh
- See changes instantly without needing to wait for bundling

## Issue(s)

Closes #72

## Changelog

### Changed
- Serve unbundled JS in development. [#72]
- Target production JS bundles to specific browser versions.

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
