### PR TITLE
[#85]: Add Changelog page, format Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](changelog),
-and this project adheres to [Semantic Versioning](semver).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased](https://github.com/paulshryock/paul-shryock/compare/HEAD..HEAD)
 
 ### Added
 - Add repository files.
@@ -56,7 +56,3 @@ and this project adheres to [Semantic Versioning](semver).
 ### Fixed
 
 ### Security
-
-[changelog]: https://keepachangelog.com/en/1.0.0/
-[semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/paulshryock/paul-shryock/compare/HEAD..HEAD

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -698,7 +698,7 @@ async function javascript () {
 	}
 
 	// Passthrough un-bundled JavaScript.
-	return src(paths.javascript.src)
+	return src(paths.javascript.entry)
 		.pipe(sourcemaps.init())
 		// Rewrite directory path.
 		.pipe(rename(path => {
@@ -859,6 +859,7 @@ function version () {
 	const url = repository.url.replace('git+', '').replace('.git', '')
 	const [month, date, year] = new Date().toLocaleDateString('en-US').split('/')
 	const today = `${month}/${date}/${year}`
+	const header = `## [${version}](${url}/releases/tags/v${version}) - ${today}`
 
 	/**
 	 * Bump docblock version.
@@ -889,29 +890,25 @@ function version () {
 
 		// Changelog.
 		src(paths.changelog)
-			// Bump unreleased version.
-			.pipe(replace('## [Unreleased]', `## [${version}] - ${today}`))
+			// Bump unreleased version and add today's date.
+			.pipe(replace(/## \[Unreleased\]\(.*\)/, header))
 			// Remove empty changelog subheads.
 			.pipe(replace(
 				/### \(Added|Changed|Deprecated|Removed|Fixed|Security\)\\n\\n/g,
 				''
 			))
-			// Add default unreleased section.
+			// Add unreleased section.
 			.pipe(replace(
-				`## [${version}] - ${today}`,
-				'## [Unreleased]\n\n' +
+				header,
+				`## [Unreleased](${url}/compare/HEAD..${version})\n\n` +
 				'### Added\n\n' +
 				'### Changed\n\n' +
 				'### Deprecated\n\n' +
 				'### Removed\n\n' +
 				'### Fixed\n\n' +
 				'### Security\n\n' +
-				`## [${version}] - ${today}`
+				header
 			))
-			// Bump unreleased link and add new release link.
-			.pipe(replace(
-				/\/compare\/HEAD..\(HEAD\|\\d*\.\\d*\.\\d*\)/g,
-				`/compare/HEAD..${version}\n[${version}]: ${url}/commits/${version}`))
 			.pipe(dest('./'))
 	)
 

--- a/src/pshry.com/content/pages/changelog.md
+++ b/src/pshry.com/content/pages/changelog.md
@@ -1,0 +1,7 @@
+---js
+{
+	changelog: require('fs').readFileSync('./CHANGELOG.md'),
+	slug: 'changelog',
+}
+---
+{{ changelog }}


### PR DESCRIPTION
## Summary
This adds a `/changelog` page which automatically pulls content from this repository's `CHANGELOG.md` file.

## Testing
- Run `npm run build`
- Visit http://localhost:8000/changelog
- See the Changelog page

## Issue(s)

Closes #85

## Changelog

## Added
- Add Changelog page [#85]

### Changed
- Format Changelog
- Improve automatic Changelog bump

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [ ] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
