### PR TITLE
[#69]: Only allow approved HTTP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/paulshryock/paul-shryock/compare/HEAD..0.0.1)
 
 ### Added
-- Add `.npmrc`
+- Add `.npmrc`.
+- Only allow approved HTTP methods [#69]
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Set HTTP headers and redirects in `netlify.toml` using `[[headers]]` and `[[redi
 echo -n "console.log('hello world')" | openssl sha256 -binary | openssl base64
 ```
 
+#### Access-Control-Allow-Methods
+
+Only `GET` requests are allowed on all routes. Other HTTP methods will need to opened up on specific routes as needed.
+
 ## Open Source
 
 This project is open source and the code is publicly [available on GitHub][github-repo].

--- a/src/pshry.com/content/headers.liquid
+++ b/src/pshry.com/content/headers.liquid
@@ -5,4 +5,5 @@ scripts: false
 stylesheets: false
 ---
 /*
+	Access-Control-Allow-Methods: GET
 	Content-Security-Policy: {{ site.csp }}


### PR DESCRIPTION
## Summary
This change only allows GET requests to all routes. Other methods will need to be opened up later for specific routes as needed.

## Testing
- Try to access the site using other HTTP methods
- Verify the request is denied

## Issue(s)
Closes #69

## Changelog

### Added
- Only allow approved HTTP methods [#69]

## Release Checklist
- [ ] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [x] I have updated the Docs
- [ ] I have updated the Readme
