### PR TITLE
[#91]: Replace flexbox gap with margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Replace flexbox gap with margin. [#91]
 
 ### Security
 - Update dependencies.

--- a/src/pshry.com/assets/sass/components/_masthead.scss
+++ b/src/pshry.com/assets/sass/components/_masthead.scss
@@ -2,7 +2,11 @@
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
-	gap: $space;
+	margin: calc(-0.5 * #{$space});
+
+	> * {
+		margin: calc(0.5 * #{$space});
+	}
 
 	> :last-child {
 		@include mq-600 {

--- a/src/pshry.com/assets/sass/components/_masthead.scss
+++ b/src/pshry.com/assets/sass/components/_masthead.scss
@@ -2,9 +2,11 @@
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
+	/* @hack: No flexbox gap support in Safari. */
 	margin: calc(-0.5 * #{$space});
 
 	> * {
+		/* @hack: No flexbox gap support in Safari. */
 		margin: calc(0.5 * #{$space});
 	}
 

--- a/src/pshry.com/assets/sass/components/_navigation.scss
+++ b/src/pshry.com/assets/sass/components/_navigation.scss
@@ -2,7 +2,10 @@
 	&__list {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 0 $space;
-		margin: 0;
+		margin: 0 calc(-0.5 * #{$space});
+
+		> * {
+			margin: 0 calc(0.5 * #{$space});
+		}
 	}
 }

--- a/src/pshry.com/assets/sass/components/_navigation.scss
+++ b/src/pshry.com/assets/sass/components/_navigation.scss
@@ -2,9 +2,11 @@
 	&__list {
 		display: flex;
 		flex-wrap: wrap;
+		/* @hack: No flexbox gap support in Safari. */
 		margin: 0 calc(-0.5 * #{$space});
 
 		> * {
+			/* @hack: No flexbox gap support in Safari. */
 			margin: 0 calc(0.5 * #{$space});
 		}
 	}

--- a/src/pshry.com/assets/sass/utilities/_font.scss
+++ b/src/pshry.com/assets/sass/utilities/_font.scss
@@ -1,32 +1,32 @@
 .font {
-  &-size {
-    &_smaller {
-      font-size: smaller;
-    }
+	&-size {
+		&_smaller {
+			font-size: smaller;
+		}
 
-    &_larger {
-      font-size: larger;
-    }
+		&_larger {
+			font-size: larger;
+		}
 
-    &_150 {
-      font-size: 1.5em;
-    }
-  }
+		&_150 {
+			font-size: 1.5em;
+		}
+	}
 
-  &-weight {
-    &_400 {
-      font-weight: 400;
-    }
-  }
+	&-weight {
+		&_400 {
+			font-weight: 400;
+		}
+	}
 
-  &-outline {
-    text-decoration: none;
-    -webkit-text-fill-color: transparent;
-    -webkit-text-stroke: thin currentColor;
+	&-outline {
+		text-decoration: none;
+		-webkit-text-fill-color: transparent;
+		-webkit-text-stroke: thin currentColor;
 
-    &:hover,
-    &:focus {
-      -webkit-text-fill-color: currentColor;
-    }
-  }
+		&:hover,
+		&:focus {
+			-webkit-text-fill-color: currentColor;
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Safari doesn't support `gap` for flexbox containers. Until this has widespread support, I'm switching back to `margin` for flexbox containers and children.

## Testing
- Open the site in Safari and confirm that masthead and navigation elements are spaced correctly

## Issue(s)
Closes #91

## Changelog

## Fixed
- Replace flexbox gap with margin. [#91]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
