### PR TITLE
hotfix: Move monogram letter to data attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Move monogram letter to data attribute.
 
 ### Security
 

--- a/src/pshry.com/assets/sass/components/_masthead.scss
+++ b/src/pshry.com/assets/sass/components/_masthead.scss
@@ -2,6 +2,7 @@
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
+
 	/* @hack: No flexbox gap support in Safari. */
 	margin: calc(-0.5 * #{$space});
 

--- a/src/pshry.com/assets/sass/components/_monogram.scss
+++ b/src/pshry.com/assets/sass/components/_monogram.scss
@@ -21,6 +21,10 @@
 		line-height: 1;
 		position: absolute;
 
+		&::before {
+			content: attr(data-monogram-letter);
+		}
+
 		&:first-child {
 			color: $monogram-first-color;
 			left: -0.0625em;

--- a/src/pshry.com/assets/sass/components/_navigation.scss
+++ b/src/pshry.com/assets/sass/components/_navigation.scss
@@ -2,6 +2,7 @@
 	&__list {
 		display: flex;
 		flex-wrap: wrap;
+
 		/* @hack: No flexbox gap support in Safari. */
 		margin: 0 calc(-0.5 * #{$space});
 

--- a/src/pshry.com/includes/components/colophon.liquid
+++ b/src/pshry.com/includes/components/colophon.liquid
@@ -1,3 +1,3 @@
-    <footer class="colophon pad">
-      <p class="colophon__copyright">{{ colophon.copyright }}</p>
+    <footer class="colophon pad" role="contentinfo">
+    	{% include components/copyright %}
     </footer>

--- a/src/pshry.com/includes/components/copyright.liquid
+++ b/src/pshry.com/includes/components/copyright.liquid
@@ -1,0 +1,1 @@
+<p class="colophon__copyright">{{ colophon.copyright }}</p>

--- a/src/pshry.com/includes/components/masthead.liquid
+++ b/src/pshry.com/includes/components/masthead.liquid
@@ -1,4 +1,4 @@
-<header class="masthead pad">
+<header class="masthead pad" role="banner">
 	{% include components/monogram %}
 	<a href="/">{{ site.title }}</a>
 	{% include components/navigation %}

--- a/src/pshry.com/includes/components/monogram.liquid
+++ b/src/pshry.com/includes/components/monogram.liquid
@@ -1,7 +1,5 @@
-<a class="monogram__link" href="/">
-	<abbr class="monogram" title="{{ monogram.title }}">
-		{% for letter in monogram.letters %}
-		<span class="monogram__letter" data-monogram-letter="{{ letter }}"></span>
-		{% endfor %}
-	</abbr>
-</a>
+<abbr class="monogram" title="{{ monogram.title }}" aria-hidden="true">
+	{% for letter in monogram.letters %}
+	<span class="monogram__letter" data-monogram-letter="{{ letter }}"></span>
+	{% endfor %}
+</abbr>

--- a/src/pshry.com/includes/components/monogram.liquid
+++ b/src/pshry.com/includes/components/monogram.liquid
@@ -1,7 +1,7 @@
 <a class="monogram__link" href="/">
 	<abbr class="monogram" title="{{ monogram.title }}">
 		{% for letter in monogram.letters %}
-		<span class="monogram__letter">{{ letter }}</span>
+		<span class="monogram__letter" data-monogram-letter="{{ letter }}"></span>
 		{% endfor %}
 	</abbr>
 </a>

--- a/src/pshry.com/includes/components/site-title.liquid
+++ b/src/pshry.com/includes/components/site-title.liquid
@@ -1,0 +1,1 @@
+<a href="/">{{ site.title }}</a>


### PR DESCRIPTION
## Summary
In the masthead, the monogram letters should be purely decorative or presentational. They're not intended to be visible to HTML-only views, search engines, RSS feeds, or screen readers.

## Testing

## Issue(s)

## Changelog

### Fixed
- Move monogram letter to data attribute.

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
