### PR TITLE
[50]: Automate GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/paulshryock/paul-shryock/compare/HEAD..0.0.3)
 
 ### Added
+- Automate GitHub releases. [#50]
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,14 @@
     "build": "gulp build",
     "serve": "gulp serve",
     "version": "gulp version && git add .",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push -u origin HEAD && git push --tags && npm run release",
+    "release": "gh release create v$(npm run get:release:version) -n \"$(npm run get:release:notes)\" $(npm run get:release:version:pre) && npm run get:tags",
+    "get:release:version": "awk -F'\"' '/\"version\": \".+\"/{ print $4; exit; }' package.json",
+    "get:release:version:pre": "MAJOR=$(npm run get:release:version | cut -c 1); if [ $MAJOR == 0 ]; then echo \"-p\"; fi",
+    "get:release:notes": "sed -n \"$(npm run get:release:notes:start),$(npm run get:release:notes:end)p\" CHANGELOG.md",
+    "get:release:notes:start": "START=$(grep -n \"\\[$(npm run get:release:version)\\]\" CHANGELOG.md | head -n 1 | cut -d: -f1); ((START=START+2)); echo $START",
+    "get:release:notes:end": "END=$(grep -n \"\\[$(git tag | sed -n 'x;$p' | tr -d 'v')\\]\" CHANGELOG.md | head -n 1 | cut -d: -f1); ((END=END-2)); echo $END",
+    "get:tags": "git fetch --tags origin"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary
To further automate the release process, after committing, tagging, and pushing the release code, this change takes it one step further and automatically creates a GitHub release with release notes from the Changelog.

## Testing
- Run `npm version <major|minor|patch>`
- Open the repository on GitHub and navigate to the project's releases
- See the latest release

## Issue(s)
Closes #50

## Changelog

### Added
- Automate GitHub releases. [#50]

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
