### PR TITLE
[#114]: Remove horizontal scroll and ditch the extra page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+- Ditch the extra page title. [#114]
 
 ### Fixed
+- Remove horizontal scroll. [#114]
 
 ### Security
 

--- a/src/pshry.com/assets/sass/components/_site.scss
+++ b/src/pshry.com/assets/sass/components/_site.scss
@@ -3,19 +3,6 @@
 	grid-template-columns: 1fr;
 	grid-template-rows: auto 1fr auto;
 	min-height: 100vh;
+	overflow-x: hidden;
 	position: relative;
-
-	&::before {
-		color: $headline-color;
-		content: attr(data-title);
-		font-size: 10em;
-		font-weight: 100;
-		line-height: 1;
-		opacity: 0.05;
-		position: absolute;
-		right: $space;
-		top: $space;
-		writing-mode: vertical-rl;
-		z-index: -1;
-	}
 }

--- a/src/pshry.com/layouts/scaffold.liquid
+++ b/src/pshry.com/layouts/scaffold.liquid
@@ -4,10 +4,7 @@ body_classes: stack
 <!DOCTYPE html>
 <html class="no-js" lang="{{ site.lang }}" data-env="{{ env.environment }}">
 {% include meta/head %}
-  <body
-  	class="site{% if body_classes %} {{ body_classes }}{% endif %}"
-  	{%- if title %} data-title="{{ title }}"{% endif -%}
-  >
+  <body class="site{% if body_classes %} {{ body_classes }}{% endif %}">
     {{ content }}
     {% include meta/scripts %}
   </body>


### PR DESCRIPTION
## Summary
The extra page title is distracting, not a great UX, and causes horizontal scrolling. Get rid of it, and prevent horizontal scrolling while we're at it.

Moving forward, responsive tables still need to be fixed in #137.

## Testing
- Confirm there is no horizontal scrollbar
- Confirm the extra page title is no longer visible or in the DOM

## Issue(s)

Closes #114

## Changelog

### Removed
- Ditch the extra page title. [#114]

### Fixed
- Remove horizontal scroll. [#114]

## Screenshot(s)

![remove-horizontal-scroll](https://user-images.githubusercontent.com/7530507/109321936-b7ecc980-781f-11eb-846f-daa005f65852.png)

## Release Checklist
- [x] I have tested this code and/or added unit tests
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
